### PR TITLE
Create cert-manager Certificates in namespace `openshift-console`

### DIFF
--- a/component/tls.libsonnet
+++ b/component/tls.libsonnet
@@ -2,6 +2,7 @@ local cm = import 'lib/cert-manager.libsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local kyverno = import 'lib/kyverno.libsonnet';
 
 local inv = kap.inventory();
 local params = inv.parameters.openshift4_console;
@@ -35,25 +36,73 @@ local secrets = std.filter(
   ]
 );
 
-local certs = std.filter(
-  function(it) it != null,
+local kyvernoAnnotation = {
+  'syn.tools/openshift4-console': 'secret-target-namespace',
+};
+
+local makeCert(c, cert) =
+  assert
+    std.member(inv.applications, 'kyverno') :
+    'You need to add component `kyverno` to the cluster to be able to deploy cert-manager Certificate resources for the the openshift web console.';
   [
-    local cert = params.cert_manager_certs[c];
-    if cert != null then
-      cm.cert(c) {
-        metadata+: {
-          // Certificates must be deployed in namespace openshift-config
-          namespace: 'openshift-config',
-        },
-        spec+: {
-          secretName: '%s' % c,
-        },
-      } + com.makeMergeable(cert)
-    for c in std.objectFields(params.cert_manager_certs)
-  ]
-);
+    cm.cert(c) {
+      metadata+: {
+        // Certificate must be deployed in the same namespace as the web
+        // console, otherwise OpenShift won't admit the HTTP01 solver route.
+        // We copy the resulting secret to namespace 'openshift-config' with
+        // Kyverno, see below.
+        namespace: params.namespace,
+      },
+      spec+: {
+        secretName: '%s' % c,
+      },
+    } + com.makeMergeable(cert),
+    kyverno.ClusterPolicy('openshift4-console-sync-' + c) {
+      spec: {
+        rules: [
+          {
+            name: 'Sync "%s" certificate secret to openshift-config' % c,
+            match: {
+              resources: {
+                kinds: [ 'Namespace' ],
+                // We copy the created TLS secret into all namespaces which
+                // have the annotation specified in `kyvernoAnnotation`.
+                annotations: kyvernoAnnotation,
+              },
+            },
+            generate: {
+              kind: 'Secret',
+              name: c,
+              namespace: '{{request.object.metadata.name}}',
+              synchronize: true,
+              clone: {
+                namespace: params.namespace,
+                name: c,
+              },
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+local certs =
+  std.foldl(
+    function(arr, e) arr + e,
+    std.filter(
+      function(it) it != null,
+      [
+        local cert = params.cert_manager_certs[c];
+        if cert != null then
+          makeCert(c, cert)
+        for c in std.objectFields(params.cert_manager_certs)
+      ],
+    ),
+    []
+  );
 
 {
   certs: certs,
   secrets: secrets,
+  kyvernoAnnotation: kyvernoAnnotation,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -117,6 +117,12 @@ This allows users to remove certificates which were configured higher up in the 
 The dictionary keys are used as `metadata.name` and `spec.secretName` for the resulting `Certificate` resources.
 The dictionary values are then directly directly merged into the mostly empty `Certificate` resources.
 
+OpenShift won't admit the route for the HTTP01 solver pod unless the `Certificate` resources are deployed in the same namespace as the web console.
+This behavior is caused by a security feature in the OpenShift ingress controller operator to not allow malicious actors to abuse hostnames which are already in use in other namespaces.
+
+However, since OpenShift requires that custom TLS secrets for the OpenShift console are stored in namespace `openshift-config`, we deploy a Kyverno policy to clone the TLS secret created by cert-manager into namespace `openshift-config` for each `Certificate` resource.
+Because of that, the component requires that Kyverno is installed on the cluster via the https://hub.syn.tools/kyverno/[Commodore component `kyverno`], when `Certificate` resources are configured in the hierarchy.
+
 
 == Example: Custom hostname in cluster's app domain
 

--- a/tests/custom-route-managed-tls.yml
+++ b/tests/custom-route-managed-tls.yml
@@ -1,3 +1,5 @@
+applications:
+  - kyverno
 parameters:
   kapitan:
     dependencies:
@@ -7,6 +9,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.3.2/lib/resource-locker.libjsonnet
         output_path: vendor/lib/resource-locker.libjsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.4.0/lib/kyverno.libsonnet
+        output_path: vendor/lib/kyverno.libsonnet
 
   resource_locker:
     namespace: syn-resource-locker

--- a/tests/custom-route-managed-tls.yml
+++ b/tests/custom-route-managed-tls.yml
@@ -5,7 +5,7 @@ parameters:
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.2.0/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.1.0/lib/resource-locker.libjsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.3.2/lib/resource-locker.libjsonnet
         output_path: vendor/lib/resource-locker.libjsonnet
 
   resource_locker:

--- a/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/01_certs.yaml
+++ b/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/01_certs.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: console-cluster-example-org-tls
   name: console-cluster-example-org-tls
-  namespace: openshift-config
+  namespace: openshift-console
 spec:
   dnsNames:
     - console.cluster.example.org
@@ -13,3 +13,28 @@ spec:
     kind: ClusterIssuer
     name: letsencrypt-staging
   secretName: console-cluster-example-org-tls
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: openshift4-console-sync-console-cluster-example-org-tls
+  name: openshift4-console-sync-console-cluster-example-org-tls
+spec:
+  rules:
+    - generate:
+        clone:
+          name: console-cluster-example-org-tls
+          namespace: openshift-console
+        kind: Secret
+        name: console-cluster-example-org-tls
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: true
+      match:
+        resources:
+          annotations:
+            syn.tools/openshift4-console: secret-target-namespace
+          kinds:
+            - Namespace
+      name: Sync "console-cluster-example-org-tls" certificate secret to openshift-config

--- a/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
+++ b/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
@@ -2,16 +2,16 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    name: cluster-manager
-  name: cluster-manager
+    name: ingress-config-openshift-io-cluster-manager
+  name: ingress-config-openshift-io-cluster-manager
   namespace: syn-resource-locker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    name: syn-resource-locker-cluster-manager
-  name: syn-resource-locker-cluster-manager
+    name: syn-resource-locker-ingress-config-openshift-io-cluster-manager
+  name: syn-resource-locker-ingress-config-openshift-io-cluster-manager
 rules:
   - apiGroups:
       - config.openshift.io
@@ -27,15 +27,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    name: syn-resource-locker-cluster-manager
-  name: syn-resource-locker-cluster-manager
+    name: syn-resource-locker-ingress-config-openshift-io-cluster-manager
+  name: syn-resource-locker-ingress-config-openshift-io-cluster-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: syn-resource-locker-cluster-manager
+  name: syn-resource-locker-ingress-config-openshift-io-cluster-manager
 subjects:
   - kind: ServiceAccount
-    name: cluster-manager
+    name: ingress-config-openshift-io-cluster-manager
     namespace: syn-resource-locker
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
@@ -45,8 +45,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: cluster
-  name: cluster
+    name: ingress-config-openshift-io-cluster
+  name: ingress-config-openshift-io-cluster
   namespace: syn-resource-locker
 spec:
   patches:
@@ -60,4 +60,4 @@ spec:
         kind: Ingress
         name: cluster
   serviceAccountRef:
-    name: cluster-manager
+    name: ingress-config-openshift-io-cluster-manager

--- a/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/20_openshift_config_ns_annotation_patch.yaml
+++ b/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/20_openshift_config_ns_annotation_patch.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: namespace-openshift-config-manager
+  name: namespace-openshift-config-manager
+  namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: syn-resource-locker-namespace-openshift-config-manager
+  name: syn-resource-locker-namespace-openshift-config-manager
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: syn-resource-locker-namespace-openshift-config-manager
+  name: syn-resource-locker-namespace-openshift-config-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-namespace-openshift-config-manager
+subjects:
+  - kind: ServiceAccount
+    name: namespace-openshift-config-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '5'
+  labels:
+    name: namespace-openshift-config
+  name: namespace-openshift-config
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: "\"metadata\":\n  \"annotations\":\n    \"syn.tools/openshift4-console\"\
+        : \"secret-target-namespace\""
+      patchType: application/merge-patch+json
+      targetObjectRef:
+        apiVersion: v1
+        kind: Namespace
+        name: openshift-config
+  serviceAccountRef:
+    name: namespace-openshift-config-manager


### PR DESCRIPTION
This feature requires Kyverno to be installed on the cluster. The component checks whether component `kyverno` is enabled on the cluster if you configure cert-manager Certificate resources for the web console. If the kvyerno component isn't enabled, the component compilation produces an error.

The component only depends on Kyverno for configurations which use cert-manager Certificates for a custom console route.

Fixes #21

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
