### PR TITLE
Generate favicon `Route` if a custom logo is configured

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
           - custom-route-legacy-4.7
           - custom-route-managed-tls
           - custom-links
+          - custom-logo
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -60,6 +61,7 @@ jobs:
           - custom-route-legacy-4.7
           - custom-route-managed-tls
           - custom-links
+          - custom-logo
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/.sync.yml
+++ b/.sync.yml
@@ -11,6 +11,7 @@
       - custom-route-legacy-4.7
       - custom-route-managed-tls
       - custom-links
+      - custom-logo
 
 .github/workflows/test.yaml:
   goldenTest_makeTarget: golden-diff -e instance=${{ matrix.instance }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -41,4 +41,4 @@ COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/custom-route.yml tests/custom-route-4.7.yml tests/custom-route-legacy.yml tests/custom-route-legacy-4.7.yml tests/custom-route-managed-tls.yml tests/custom-links.yml
+test_instances = tests/defaults.yml tests/custom-route.yml tests/custom-route-4.7.yml tests/custom-route-legacy.yml tests/custom-route-legacy-4.7.yml tests/custom-route-managed-tls.yml tests/custom-links.yml tests/custom-logo.yml

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -114,6 +114,13 @@ The filename needs to have a filename extension which matches the image format.
 For SVG logos the file must *not* be base64 encoded, but inserted directly as a string.
 ====
 
+By default, OCP won't serve a favicon if a custom logo is configured for the console.
+This is an intentional design decision as documented in this https://bugzilla.redhat.com/show_bug.cgi?id=1844883#c1[bug report].
+
+The component tries to ensure that a favicon is served even if a custom logo is configured.
+However, because the current workaround for the missing favicon requires an additional custom route for the console hostname, it can only be implemented for configurations which use a custom console hostname.
+Otherwise, the component is unable to correctly configure `spec.hostname` for the console.
+
 == `secrets`
 
 [horizontal]

--- a/tests/custom-logo.yml
+++ b/tests/custom-logo.yml
@@ -1,6 +1,19 @@
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.1.0/lib/resource-locker.libjsonnet
+        output_path: vendor/lib/resource-locker.libjsonnet
+
+  resource_locker:
+    namespace: syn-resource-locker
+
   openshift4_console:
     config:
+      route:
+        hostname: console.company.cloud
+        secret:
+          name: console-company-cloud-tls
       customization:
         customProductName: Company Cloud
     custom_logo:

--- a/tests/golden/custom-logo/openshift4-console/openshift4-console/00_namespace.yaml
+++ b/tests/golden/custom-logo/openshift4-console/openshift4-console/00_namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/master=
   labels:
     name: openshift-console
   name: openshift-console

--- a/tests/golden/custom-logo/openshift4-console/openshift4-console/10_console_favicon_route.yaml
+++ b/tests/golden/custom-logo/openshift4-console/openshift4-console/10_console_favicon_route.yaml
@@ -1,0 +1,23 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/rewrite-target: /static/assets/openshift-favicon.png
+  labels:
+    app: console
+    name: console-favicon
+  name: console-favicon
+  namespace: openshift-console
+spec:
+  host: console.company.cloud
+  path: /favicon.ico
+  port:
+    targetPort: https
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: console
+    weight: 100
+  wildcardPolicy: None

--- a/tests/golden/custom-logo/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
+++ b/tests/golden/custom-logo/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: cluster-manager
+  name: cluster-manager
+  namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: syn-resource-locker-cluster-manager
+  name: syn-resource-locker-cluster-manager
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: syn-resource-locker-cluster-manager
+  name: syn-resource-locker-cluster-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-cluster-manager
+subjects:
+  - kind: ServiceAccount
+    name: cluster-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: cluster
+  name: cluster
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: "\"spec\":\n  \"componentRoutes\":\n  - \"hostname\": \"console.company.cloud\"\
+        \n    \"name\": \"console\"\n    \"namespace\": \"openshift-console\"\n  \
+        \  \"servingCertKeyPairSecret\":\n      \"name\": \"console-company-cloud-tls\""
+      patchType: application/merge-patch+json
+      targetObjectRef:
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        name: cluster
+  serviceAccountRef:
+    name: cluster-manager


### PR DESCRIPTION
When the OCP console is customized, the default favicon is not served, which is an intentional design decision, as documented in https://bugzilla.redhat.com/show_bug.cgi?id=1844883#c1.

However, that bugzilla provides a workaround to restore the default favicon when the console is customized, cf. https://bugzilla.redhat.com/show_bug.cgi?id=1844883#c3. We implement this workaround in this commit if the console logo is customized, and a custom hostname is configured, as we otherwise can't configure `spec.hostname` for the additional route.

Ideally, we'd like to allow users to configure a custom favicon if they're customizing the logo, but that's currently not possible.

Fixes https://github.com/appuio/component-openshift4-console/issues/27

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
