### PR TITLE
Add support for patch-operator-backed patches

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -162,7 +162,7 @@ local consoleRoutePatch =
       },
     };
     [
-      if obj.kind == 'ResourceLocker' then
+      if std.member([ 'ResourceLocker', 'Patch' ], obj.kind) then
         obj {
           metadata+: {
             annotations+: {
@@ -207,7 +207,7 @@ local openshiftConfigNsAnnotationPatch =
       },
     };
     [
-      if obj.kind == 'ResourceLocker' then
+      if std.member([ 'ResourceLocker', 'Patch' ], obj.kind) then
         obj {
           metadata+: {
             annotations+: {


### PR DESCRIPTION
We modify the resources returned by `rl.Patch()` to inject custom ArgoCD sync-wave annotations. In order to ensure this functionality isn't lost when migrating to patch-operator-backed patches, we adjust the component to also inject the sync-wave annotations for resources with `kind: Patch`.

Note that we aren't migrating to importing `patch-operator.libsonnet` directly to make this change backwards-compatible.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
