### PR TITLE
Revert ignore plugin differences

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,19 +3,7 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_console;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('openshift4-console', params.namespace, secrets=false) {
-  spec+: {
-    ignoreDifferences+: [
-      {
-        group: 'operator.openshift.io',
-        kind: 'Console',
-        jsonPointers: [
-          '/spec/plugins',
-        ],
-      },
-    ],
-  },
-};
+local app = argocd.App('openshift4-console', params.namespace, secrets=false);
 
 {
   'openshift4-console': app,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -77,13 +77,6 @@ default:: `[]`
 
 Add plugins to the console.
 
-[IMPORTANT]
-====
-While adding custom plugins is supported, Argo CD will ignore differences to allow other components to patch this field.
-
-Manual syncs in Argo CD may be necessary.
-====
-
 === `config.route`
 
 [horizontal]

--- a/tests/golden/custom-links/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-links/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-logo/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-logo/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-plugins/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-plugins/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-route-4.7/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-route-4.7/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-route-legacy-4.7/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-route-legacy-4.7/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-route-legacy/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-route-legacy/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-route-managed-tls/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-route-managed-tls/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/custom-route/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/custom-route/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console

--- a/tests/golden/defaults/openshift4-console/apps/openshift4-console.yaml
+++ b/tests/golden/defaults/openshift4-console/apps/openshift4-console.yaml
@@ -1,6 +1,0 @@
-spec:
-  ignoreDifferences:
-    - group: operator.openshift.io
-      jsonPointers:
-        - /spec/plugins
-      kind: Console


### PR DESCRIPTION
This partially reverts the changes of #50 to only manage plugins through this component since patching a list from multiple sources is not possible with the current tooling.

See https://github.com/appuio/component-openshift4-logging/pull/97 for an alternative approach.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

