### PR TITLE
Add capabilities for 4.21

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -225,20 +225,6 @@ local consoleSpec =
     else {}
   ) + (
     if openshiftMinor > 18 then
-      local availableCaps = {
-        '19': std.set([
-          'LightspeedButton',
-          'GettingStartedBanner',
-        ]),
-        '20': std.set([
-          'LightspeedButton',
-          'GettingStartedBanner',
-        ]),
-        '21': std.set([
-          'LightspeedButton',
-          'GettingStartedBanner',
-        ]),
-      };
       {
         local existingCaps = std.set(
           [ c.name for c in std.get(super.customization, 'capabilities', []) ]
@@ -254,9 +240,7 @@ local consoleSpec =
               },
             }
             for name in std.objectFields(params.capabilities)
-            if
-              !std.setMember(name, existingCaps) &&
-              std.setMember(name, availableCaps[params.openshift_version.Minor])
+            if !std.setMember(name, existingCaps)
           ],
         },
       } else {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -234,6 +234,10 @@ local consoleSpec =
           'LightspeedButton',
           'GettingStartedBanner',
         ]),
+        '21': std.set([
+          'LightspeedButton',
+          'GettingStartedBanner',
+        ]),
       };
       {
         local existingCaps = std.set(


### PR DESCRIPTION
With the switch to espejote in #98 we no longer manage the whole console object, but only patch the required parts with a a managed resource.

We therefore no longer need to keep track of the available capabilities by OpenShift minor version in the component. New capabilities will be added by the OpenShift and we can patch the visibility if needed.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
