### PR TITLE
Mark cluster scoped Console object with Prune=false

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -423,6 +423,11 @@ local notifications = import 'notifications.libsonnet';
       },
     },
   '10_console': kube._Object(versionGroup, 'Console', 'cluster') {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'Prune=false',
+      },
+    },
     spec+: consoleSpec,
   },
   [if faviconRoute != null then '10_console_favicon_route']:

--- a/tests/golden/custom-links/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/custom-links/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/custom-logo/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/custom-logo/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/custom-logo/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
+++ b/tests/golden/custom-logo/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
@@ -53,6 +53,7 @@ apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
     syn.tools/source: https://github.com/appuio/component-openshift4-console.git
   labels:

--- a/tests/golden/custom-plugins/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/custom-plugins/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/custom-route-legacy/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/custom-route-legacy/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/custom-route-legacy/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
+++ b/tests/golden/custom-route-legacy/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
@@ -53,6 +53,7 @@ apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
     syn.tools/source: https://github.com/appuio/component-openshift4-console.git
   labels:

--- a/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
+++ b/tests/golden/custom-route-managed-tls/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
@@ -53,6 +53,7 @@ apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
     syn.tools/source: https://github.com/appuio/component-openshift4-console.git
   labels:

--- a/tests/golden/custom-route/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/custom-route/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/custom-route/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
+++ b/tests/golden/custom-route/openshift4-console/openshift4-console/20_ingress_config_patch.yaml
@@ -53,6 +53,7 @@ apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
     syn.tools/source: https://github.com/appuio/component-openshift4-console.git
   labels:

--- a/tests/golden/defaults/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/defaults/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/notifications/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/notifications/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster

--- a/tests/golden/upgrade-notification/openshift4-console/openshift4-console/10_console.yaml
+++ b/tests/golden/upgrade-notification/openshift4-console/openshift4-console/10_console.yaml
@@ -1,6 +1,8 @@
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: cluster
   name: cluster


### PR DESCRIPTION
This prepares for the next release when we will manage the Console object with espejote

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
