### PR TITLE
Ensure dynamic facts are updated if scheduled upgrade is removed

### DIFF
--- a/component/espejote-templates/upgrade-notification.jsonnet
+++ b/component/espejote-templates/upgrade-notification.jsonnet
@@ -86,5 +86,7 @@ local updateDynamicFacts(nextDate, nextVersion) =
 if upgradeWindow != null then [
   makeConsoleNotification('minor-upgrade-notification', config.notification, replacementValues),
   updateDynamicFacts(std.get(replacementValues, '$NEXT_MAINTENANCE', 'N/A'), std.get(replacementValues, '$OVERLAY_VERSION', 'N/A')),
-] else
-  esp.markForDelete(makeConsoleNotification('minor-upgrade-notification', { text: '' }, {}))
+] else [
+  esp.markForDelete(makeConsoleNotification('minor-upgrade-notification', { text: '' }, {})),
+  updateDynamicFacts('', ''),
+]

--- a/tests/golden/upgrade-notification/openshift4-console/openshift4-console/31_upgrade_notification.yaml
+++ b/tests/golden/upgrade-notification/openshift4-console/openshift4-console/31_upgrade_notification.yaml
@@ -125,8 +125,10 @@ spec:
     if upgradeWindow != null then [
       makeConsoleNotification('minor-upgrade-notification', config.notification, replacementValues),
       updateDynamicFacts(std.get(replacementValues, '$NEXT_MAINTENANCE', 'N/A'), std.get(replacementValues, '$OVERLAY_VERSION', 'N/A')),
-    ] else
-      esp.markForDelete(makeConsoleNotification('minor-upgrade-notification', { text: '' }, {}))
+    ] else [
+      esp.markForDelete(makeConsoleNotification('minor-upgrade-notification', { text: '' }, {})),
+      updateDynamicFacts('', ''),
+    ]
   triggers:
     - name: clusterversion_appuio
       watchContextResource:


### PR DESCRIPTION
In https://github.com/appuio/component-openshift4-console/pull/99#discussion_r3587642160 we discussed that "re-setting" the dynamic facts is not strictly necessary. However we didn't consider the scenario where a version overlay is removed (e.g. to postpone/cancel a minor upgrade). Then the wrong dynamic fact will stay active. That's not intended and highly confusing.

This PR sets the dynamic facts `openshiftNextMinorDate` and `openshiftNextMinorVersion` to empty strings, when there's no scheduled, upcoming minor upgrade. 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
